### PR TITLE
Add joystick / gamepad support using distribution html files

### DIFF
--- a/dist/console-fullscreen.html
+++ b/dist/console-fullscreen.html
@@ -111,10 +111,11 @@
         var scale = 1;      
         var margintop = 0;
         var marginleft = 0;
-
+        var doGamepadReset = false;
         var urlParams = new URLSearchParams(window.location.search);
         var emulator = new metaEmulator.Emulator("emulator");
         emulator.loadFromUrl(urlParams.has('bin') ? urlParams.get('bin') : "https://raw.githubusercontent.com/Rodot/Games-META/master/binaries/Solitaire/Solitaire.bin");
+        window.requestAnimationFrame(updateGamePadState);
         var consoleelem = document.getElementById("console");
         scale = setScale(consoleelem);
         const dpadX = 108;
@@ -177,6 +178,41 @@
         function handleMouseUp() {
             mousePressed = false;
             emulator.setButtonData(0b11111111);
+        }
+
+        function updateGamePadState() {
+            window.requestAnimationFrame(updateGamePadState);
+            if (!navigator) return;
+            const gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+            if (!gamepads || gamepads.length == 0) return;
+            const gamepad = gamepads[0];
+            if(!gamepad) return;
+
+            let gamepadData = 0b11111111;
+            let buttonsCount = gamepad.buttons.length;
+            let axisCount = gamepad.axes.length;
+            if ((axisCount > 0 && gamepad.axes[0] < -.9) || (buttonsCount > 14 && gamepad.buttons[14].pressed)) gamepadData &= 0b11111101;
+            if ((axisCount > 0 && gamepad.axes[0] > .9) || (buttonsCount > 15 && gamepad.buttons[15].pressed)) gamepadData &= 0b11111011;
+            if ((axisCount > 1 && gamepad.axes[1] < -.9) || (buttonsCount > 12 && gamepad.buttons[12].pressed)) gamepadData &= 0b11110111;
+            if ((axisCount > 1 && gamepad.axes[1] > .9) || (buttonsCount > 13 && gamepad.buttons[13].pressed)) gamepadData &= 0b11111110;
+            if ((buttonsCount > 1 && gamepad.buttons[1].pressed) || (buttonsCount > 3 && gamepad.buttons[3].pressed)) gamepadData &= 0b11011111;
+            if ((buttonsCount > 0 && gamepad.buttons[0].pressed) || (buttonsCount > 2 && gamepad.buttons[2].pressed)) gamepadData &= 0b11101111;
+            if ((buttonsCount > 8 && gamepad.buttons[8].pressed)) gamepadData &= 0b10111111;
+            if ((buttonsCount > 9 && gamepad.buttons[9].pressed)) gamepadData &= 0b01111111;
+            
+            if (gamepadData == 0b11111111) 
+            {
+              if(doGamepadReset)
+              {
+                doGamepadReset = false;
+                emulator.setButtonData(gamepadData)
+              }
+            }
+            else
+            {
+              doGamepadReset = true;
+              emulator.setButtonData(gamepadData);
+            }
         }
 
         function handleTouches(event) {

--- a/dist/console.html
+++ b/dist/console.html
@@ -89,10 +89,11 @@
     <script src="url-search-params.js"></script>
 
     <script>
+        var doGamepadReset = false;
         var urlParams = new URLSearchParams(window.location.search);
         var emulator = new metaEmulator.Emulator("emulator");
         emulator.loadFromUrl(urlParams.has('bin') ? urlParams.get('bin') : "https://raw.githubusercontent.com/Rodot/Games-META/master/binaries/Solitaire/Solitaire.bin");
-
+        window.requestAnimationFrame(updateGamePadState);
         const dpadX = 119;
         const dpadY = 216;
         const dpadDist = 87;
@@ -147,7 +148,42 @@
             mousePressed = false;
             emulator.setButtonData(0b11111111);
         }
+        
+        function updateGamePadState() {
+            window.requestAnimationFrame(updateGamePadState);
+            if (!navigator) return;
+            const gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+            if (!gamepads || gamepads.length == 0) return;
+            const gamepad = gamepads[0];
+            if(!gamepad) return;
 
+            let gamepadData = 0b11111111;
+            let buttonsCount = gamepad.buttons.length;
+            let axisCount = gamepad.axes.length;
+            if ((axisCount > 0 && gamepad.axes[0] < -.9) || (buttonsCount > 14 && gamepad.buttons[14].pressed)) gamepadData &= 0b11111101;
+            if ((axisCount > 0 && gamepad.axes[0] > .9) || (buttonsCount > 15 && gamepad.buttons[15].pressed)) gamepadData &= 0b11111011;
+            if ((axisCount > 1 && gamepad.axes[1] < -.9) || (buttonsCount > 12 && gamepad.buttons[12].pressed)) gamepadData &= 0b11110111;
+            if ((axisCount > 1 && gamepad.axes[1] > .9) || (buttonsCount > 13 && gamepad.buttons[13].pressed)) gamepadData &= 0b11111110;
+            if ((buttonsCount > 1 && gamepad.buttons[1].pressed) || (buttonsCount > 3 && gamepad.buttons[3].pressed)) gamepadData &= 0b11011111;
+            if ((buttonsCount > 0 && gamepad.buttons[0].pressed) || (buttonsCount > 2 && gamepad.buttons[2].pressed)) gamepadData &= 0b11101111;
+            if ((buttonsCount > 8 && gamepad.buttons[8].pressed)) gamepadData &= 0b10111111;
+            if ((buttonsCount > 9 && gamepad.buttons[9].pressed)) gamepadData &= 0b01111111;
+            
+            if (gamepadData == 0b11111111) 
+            {
+              if(doGamepadReset)
+              {
+                doGamepadReset = false;
+                emulator.setButtonData(gamepadData)
+              }
+            }
+            else
+            {
+              doGamepadReset = true;
+              emulator.setButtonData(gamepadData);
+            }
+        }
+        
         function handleTouches(event) {
             event.preventDefault();
 

--- a/dist/console2-fullscreen.html
+++ b/dist/console2-fullscreen.html
@@ -113,10 +113,11 @@
         var scale = 1;      
         var margintop = 0;
         var marginleft = 0;
-        
+        var doGamepadReset = false;
         var urlParams = new URLSearchParams(window.location.search);
         var emulator = new metaEmulator.Emulator("emulator");
         emulator.loadFromUrl(urlParams.has('bin') ? urlParams.get('bin') : "https://raw.githubusercontent.com/Rodot/Games-META/master/binaries/Solitaire/Solitaire.bin");
+        window.requestAnimationFrame(updateGamePadState);
         var consoleelem = document.getElementById("console");
         scale = setScale(consoleelem);
         const dpadX = 108;
@@ -148,7 +149,7 @@
         controls.addEventListener("mousedown", handleMouseDown);
         controls.addEventListener("mousemove", handleMouseMove);
         controls.addEventListener("mouseup", handleMouseUp);
-        
+
         function windowResize()
         {
           scale = setScale(consoleelem);
@@ -179,6 +180,41 @@
         function handleMouseUp() {
             mousePressed = false;
             emulator.setButtonData(0b11111111);
+        }
+
+        function updateGamePadState() {
+            window.requestAnimationFrame(updateGamePadState);
+            if (!navigator) return;
+            const gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+            if (!gamepads || gamepads.length == 0) return;
+            const gamepad = gamepads[0];
+            if(!gamepad) return;
+
+            let gamepadData = 0b11111111;
+            let buttonsCount = gamepad.buttons.length;
+            let axisCount = gamepad.axes.length;
+            if ((axisCount > 0 && gamepad.axes[0] < -.9) || (buttonsCount > 14 && gamepad.buttons[14].pressed)) gamepadData &= 0b11111101;
+            if ((axisCount > 0 && gamepad.axes[0] > .9) || (buttonsCount > 15 && gamepad.buttons[15].pressed)) gamepadData &= 0b11111011;
+            if ((axisCount > 1 && gamepad.axes[1] < -.9) || (buttonsCount > 12 && gamepad.buttons[12].pressed)) gamepadData &= 0b11110111;
+            if ((axisCount > 1 && gamepad.axes[1] > .9) || (buttonsCount > 13 && gamepad.buttons[13].pressed)) gamepadData &= 0b11111110;
+            if ((buttonsCount > 1 && gamepad.buttons[1].pressed) || (buttonsCount > 3 && gamepad.buttons[3].pressed)) gamepadData &= 0b11011111;
+            if ((buttonsCount > 0 && gamepad.buttons[0].pressed) || (buttonsCount > 2 && gamepad.buttons[2].pressed)) gamepadData &= 0b11101111;
+            if ((buttonsCount > 8 && gamepad.buttons[8].pressed)) gamepadData &= 0b10111111;
+            if ((buttonsCount > 9 && gamepad.buttons[9].pressed)) gamepadData &= 0b01111111;
+            
+            if (gamepadData == 0b11111111) 
+            {
+              if(doGamepadReset)
+              {
+                doGamepadReset = false;
+                emulator.setButtonData(gamepadData)
+              }
+            }
+            else
+            {
+              doGamepadReset = true;
+              emulator.setButtonData(gamepadData);
+            }
         }
 
         function handleTouches(event) {

--- a/dist/console2.html
+++ b/dist/console2.html
@@ -92,6 +92,8 @@
         var urlParams = new URLSearchParams(window.location.search);
         var emulator = new metaEmulator.Emulator("emulator");
         emulator.loadFromUrl(urlParams.has('bin') ? urlParams.get('bin') : "https://raw.githubusercontent.com/Rodot/Games-META/master/binaries/Solitaire/Solitaire.bin");
+        var doGamepadReset = false;
+        window.requestAnimationFrame(updateGamePadState);
 
         const dpadX = 119;
         const dpadY = 216;
@@ -146,6 +148,41 @@
         function handleMouseUp() {
             mousePressed = false;
             emulator.setButtonData(0b11111111);
+        }
+
+        function updateGamePadState() {
+            window.requestAnimationFrame(updateGamePadState);
+            if (!navigator) return;
+            const gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+            if (!gamepads || gamepads.length == 0) return;
+            const gamepad = gamepads[0];
+            if(!gamepad) return;
+
+            let gamepadData = 0b11111111;
+            let buttonsCount = gamepad.buttons.length;
+            let axisCount = gamepad.axes.length;
+            if ((axisCount > 0 && gamepad.axes[0] < -.9) || (buttonsCount > 14 && gamepad.buttons[14].pressed)) gamepadData &= 0b11111101;
+            if ((axisCount > 0 && gamepad.axes[0] > .9) || (buttonsCount > 15 && gamepad.buttons[15].pressed)) gamepadData &= 0b11111011;
+            if ((axisCount > 1 && gamepad.axes[1] < -.9) || (buttonsCount > 12 && gamepad.buttons[12].pressed)) gamepadData &= 0b11110111;
+            if ((axisCount > 1 && gamepad.axes[1] > .9) || (buttonsCount > 13 && gamepad.buttons[13].pressed)) gamepadData &= 0b11111110;
+            if ((buttonsCount > 1 && gamepad.buttons[1].pressed) || (buttonsCount > 3 && gamepad.buttons[3].pressed)) gamepadData &= 0b11011111;
+            if ((buttonsCount > 0 && gamepad.buttons[0].pressed) || (buttonsCount > 2 && gamepad.buttons[2].pressed)) gamepadData &= 0b11101111;
+            if ((buttonsCount > 8 && gamepad.buttons[8].pressed)) gamepadData &= 0b10111111;
+            if ((buttonsCount > 9 && gamepad.buttons[9].pressed)) gamepadData &= 0b01111111;
+            
+            if (gamepadData == 0b11111111) 
+            {
+              if(doGamepadReset)
+              {
+                doGamepadReset = false;
+                emulator.setButtonData(gamepadData)
+              }
+            }
+            else
+            {
+              doGamepadReset = true;
+              emulator.setButtonData(gamepadData);
+            }
         }
 
         function handleTouches(event) {

--- a/dist/emulator-fullscreen.html
+++ b/dist/emulator-fullscreen.html
@@ -82,9 +82,10 @@
             
             document.getElementById("start").style.display = "none";
         }
-
+        var doGamepadReset = false;
         var emulator = new metaEmulator.Emulator("emulator");
         emulator.autoStart = false;
+        window.requestAnimationFrame(updateGamePadState);
         var urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has('bin')) {
             if (urlParams.has('autostart'))
@@ -93,6 +94,41 @@
                 document.getElementById("start").style.display = "none";
             }
             emulator.loadFromUrl(urlParams.get('bin'));
+        }
+
+        function updateGamePadState() {
+            window.requestAnimationFrame(updateGamePadState);
+            if (!navigator) return;
+            const gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+            if (!gamepads || gamepads.length == 0) return;
+            const gamepad = gamepads[0];
+            if(!gamepad) return;
+
+            let gamepadData = 0b11111111;
+            let buttonsCount = gamepad.buttons.length;
+            let axisCount = gamepad.axes.length;
+            if ((axisCount > 0 && gamepad.axes[0] < -.9) || (buttonsCount > 14 && gamepad.buttons[14].pressed)) gamepadData &= 0b11111101;
+            if ((axisCount > 0 && gamepad.axes[0] > .9) || (buttonsCount > 15 && gamepad.buttons[15].pressed)) gamepadData &= 0b11111011;
+            if ((axisCount > 1 && gamepad.axes[1] < -.9) || (buttonsCount > 12 && gamepad.buttons[12].pressed)) gamepadData &= 0b11110111;
+            if ((axisCount > 1 && gamepad.axes[1] > .9) || (buttonsCount > 13 && gamepad.buttons[13].pressed)) gamepadData &= 0b11111110;
+            if ((buttonsCount > 1 && gamepad.buttons[1].pressed) || (buttonsCount > 3 && gamepad.buttons[3].pressed)) gamepadData &= 0b11011111;
+            if ((buttonsCount > 0 && gamepad.buttons[0].pressed) || (buttonsCount > 2 && gamepad.buttons[2].pressed)) gamepadData &= 0b11101111;
+            if ((buttonsCount > 8 && gamepad.buttons[8].pressed)) gamepadData &= 0b10111111;
+            if ((buttonsCount > 9 && gamepad.buttons[9].pressed)) gamepadData &= 0b01111111;
+            
+            if (gamepadData == 0b11111111) 
+            {
+              if(doGamepadReset)
+              {
+                doGamepadReset = false;
+                emulator.setButtonData(gamepadData)
+              }
+            }
+            else
+            {
+              doGamepadReset = true;
+              emulator.setButtonData(gamepadData);
+            }
         }
     </script>
 </body>

--- a/dist/emulator.html
+++ b/dist/emulator.html
@@ -55,9 +55,10 @@
     <script src="url-search-params.js"></script>
 
     <script>
+        var doGamepadReset = false;
         var emulator = new metaEmulator.Emulator("emulator");
         emulator.autoStart = false;
-        
+        window.requestAnimationFrame(updateGamePadState);
         var urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has('bin')) {
             emulator.loadFromUrl(urlParams.get('bin'));
@@ -72,6 +73,41 @@
             }
             
             document.getElementById("start").style.display = "none";
+        }
+
+        function updateGamePadState() {
+            window.requestAnimationFrame(updateGamePadState);
+            if (!navigator) return;
+            const gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+            if (!gamepads || gamepads.length == 0) return;
+            const gamepad = gamepads[0];
+            if(!gamepad) return;
+
+            let gamepadData = 0b11111111;
+            let buttonsCount = gamepad.buttons.length;
+            let axisCount = gamepad.axes.length;
+            if ((axisCount > 0 && gamepad.axes[0] < -.9) || (buttonsCount > 14 && gamepad.buttons[14].pressed)) gamepadData &= 0b11111101;
+            if ((axisCount > 0 && gamepad.axes[0] > .9) || (buttonsCount > 15 && gamepad.buttons[15].pressed)) gamepadData &= 0b11111011;
+            if ((axisCount > 1 && gamepad.axes[1] < -.9) || (buttonsCount > 12 && gamepad.buttons[12].pressed)) gamepadData &= 0b11110111;
+            if ((axisCount > 1 && gamepad.axes[1] > .9) || (buttonsCount > 13 && gamepad.buttons[13].pressed)) gamepadData &= 0b11111110;
+            if ((buttonsCount > 1 && gamepad.buttons[1].pressed) || (buttonsCount > 3 && gamepad.buttons[3].pressed)) gamepadData &= 0b11011111;
+            if ((buttonsCount > 0 && gamepad.buttons[0].pressed) || (buttonsCount > 2 && gamepad.buttons[2].pressed)) gamepadData &= 0b11101111;
+            if ((buttonsCount > 8 && gamepad.buttons[8].pressed)) gamepadData &= 0b10111111;
+            if ((buttonsCount > 9 && gamepad.buttons[9].pressed)) gamepadData &= 0b01111111;
+            
+            if (gamepadData == 0b11111111) 
+            {
+              if(doGamepadReset)
+              {
+                doGamepadReset = false;
+                emulator.setButtonData(gamepadData)
+              }
+            }
+            else
+            {
+              doGamepadReset = true;
+              emulator.setButtonData(gamepadData);
+            }
         }
     </script>
 </body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -69,8 +69,10 @@
     <script src="meta-emulator.js"></script>
 
     <script>
+        var doGamepadReset = false;
         var emulator = new metaEmulator.Emulator("emulator");
-        
+        window.requestAnimationFrame(updateGamePadState);
+
         document.getElementById("file-upload").onchange = function() {
             if (this.files.length == 1) {
                 var f = this.files[0];
@@ -213,6 +215,42 @@
                 giveInstruction("");
             };
             document.addEventListener('keydown', handler);
+        }
+
+        function updateGamePadState() {
+            window.requestAnimationFrame(updateGamePadState);
+            if (!navigator) return;
+            const gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
+            if (!gamepads || gamepads.length == 0) return;
+            const gamepad = gamepads[0];
+            if(!gamepad) return;
+
+            
+            let gamepadData = 0b11111111;
+            let buttonsCount = gamepad.buttons.length;
+            let axisCount = gamepad.axes.length;
+            if ((axisCount > 0 && gamepad.axes[0] < -.9) || (buttonsCount > 14 && gamepad.buttons[14].pressed)) gamepadData &= 0b11111101;
+            if ((axisCount > 0 && gamepad.axes[0] > .9) || (buttonsCount > 15 && gamepad.buttons[15].pressed)) gamepadData &= 0b11111011;
+            if ((axisCount > 1 && gamepad.axes[1] < -.9) || (buttonsCount > 12 && gamepad.buttons[12].pressed)) gamepadData &= 0b11110111;
+            if ((axisCount > 1 && gamepad.axes[1] > .9) || (buttonsCount > 13 && gamepad.buttons[13].pressed)) gamepadData &= 0b11111110;
+            if ((buttonsCount > 1 && gamepad.buttons[1].pressed) || (buttonsCount > 3 && gamepad.buttons[3].pressed)) gamepadData &= 0b11011111;
+            if ((buttonsCount > 0 && gamepad.buttons[0].pressed) || (buttonsCount > 2 && gamepad.buttons[2].pressed)) gamepadData &= 0b11101111;
+            if ((buttonsCount > 8 && gamepad.buttons[8].pressed)) gamepadData &= 0b10111111;
+            if ((buttonsCount > 9 && gamepad.buttons[9].pressed)) gamepadData &= 0b01111111;
+            
+            if (gamepadData == 0b11111111) 
+            {
+              if(doGamepadReset)
+              {
+                doGamepadReset = false;
+                emulator.setButtonData(gamepadData)
+              }
+            }
+            else
+            {
+              doGamepadReset = true;
+              emulator.setButtonData(gamepadData);
+            }
         }
 
     </script>


### PR DESCRIPTION
Hi,

I noticed this version of the emulator had no joystick / gamepad support, but the WASM version did. So i added joystick / gamepad support to the distribution html files for this version of the emulator.

I keep using RequestAnimationFrame to handle joypad input and i only reset the joypad button state once after not pressing any buttons / axises. If i did not do this keyboard and touch input had problems. 

This allowed me to use the emulator on my arcade cabinet as well as on the steamdeck as you can see in the video's below. (basically i used chrome / edge with local html files and made the bin= variable from within the frontends. I also had to disable websecurity to go around CORS issues from loading files using file:// protocol but this is not a problem as everything is done locally


https://user-images.githubusercontent.com/10714776/174579739-3b398b92-f9a5-4f77-9f73-d9aa6742e3f1.mp4



https://user-images.githubusercontent.com/10714776/174578943-fe1384e1-07b3-495f-b980-31d2a922c0d9.mp4


